### PR TITLE
Discard unmatched packets with seqNum == 0

### DIFF
--- a/examples/helloSoundplane.cpp
+++ b/examples/helloSoundplane.cpp
@@ -99,7 +99,7 @@ int main(int argc, const char * argv[])
 
 	std::cout << "Hello, Soundplane! v1.81 \n";
 
-	const int kTestDuration = 10;
+	const int kTestDuration = 60;
 	while(now - start < seconds(kTestDuration))
 	{
 		now = system_clock::now();

--- a/source/Unpacker.h
+++ b/source/Unpacker.h
@@ -69,8 +69,9 @@ class Unpacker
 
 	static bool lessThanHandleOverflow(uint16_t a, uint16_t b)
 	{
-		// This expression is equivalent to a < b, except that it gracefully
-		// handles serial number overflows.
+		// This expression is equivalent to a < b, except that it handles serial
+		// number overflows as long as difference between a and b is less than
+		// 2^15.
 		return static_cast<uint16_t>(b - a) < (1 << (sizeof(a) * 8 - 1));
 	}
 
@@ -125,6 +126,8 @@ public:
 				popPacket(&ts[0]);
 				popPacket(&ts[1]);
 			}
+			else if (p0.seqNum == 0) popPacket(&ts[0]);  // Discard if no sequence number
+			else if (p1.seqNum == 0) popPacket(&ts[1]);
 			else
 			{
 				// The oldest packet we have for one endpoint is older than


### PR DESCRIPTION
On Linux some percentage of the tranfers passed to the Unpacker will
include packets with seqNum == 0. If a sequence number over 2^15  and 0
are passed to lessThanHandleOverflow() then its result is inverted which
results in the incorrect packet getting discarded corrupting the
synchronization.

At ~1hz samping rate the sequence numbers exceed 2^15 around 30 sec.
The helloSoundplane test duration has been increased to 60 sec according.

---

The above change has been tested on:

| platform | note |
| -------- | ----- |
| macOS 11.5.2 + IOKit | no change, Unpacker is only used with `libusb` |
| macOS 11.5.2 + libusb | no change, previously working |
| Linux 5.10 Buster (rpi4) + libusb | fixed |
| Linux 4.19.127 norns (cm3+) + libusb | fixed |
