### PR TITLE
Use CMakeLists.txt relative include paths

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -23,8 +23,8 @@ endif()
 # Add include directories
 #--------------------------------------------------------------------
 
-include_directories("${CMAKE_SOURCE_DIR}/source")
-include_directories("${CMAKE_SOURCE_DIR}/include")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
 if(SP_USE_LIBUSB)
   pkg_check_modules(LIBUSB REQUIRED libusb-1.0)


### PR DESCRIPTION
Allows the library to be added as a subdirectory within an
existing CMake project and compiled directly, avoiding
the need for installation.