### PR TITLE
Discard matched packets when both seqNum == 0

### DIFF
--- a/source/Unpacker.h
+++ b/source/Unpacker.h
@@ -121,8 +121,8 @@ public:
 			SoundplaneADataPacket& p1 = ts[1]->currentPacket();
 			if (p0.seqNum == p1.seqNum)
 			{
-				// The sequence numbers line up
-				matchedPackets(p0, p1);
+				// The sequence numbers line up, but discard if both zero/empty
+				if (p0.seqNum != 0) matchedPackets(p0, p1);
 				popPacket(&ts[0]);
 				popPacket(&ts[1]);
 			}


### PR DESCRIPTION
The existing logic to discard packets with seqNum == 0 missed the
case when both endpoints received empty packets at the same time.
This change drops both ep0 and ep1 packets; skipping the frame
creation, when both have seqNum == 0.

On Linux this change fixes remaining periodic/spurious anomaly
errors which would trigger recalibration.